### PR TITLE
Fix version file URL property

### DIFF
--- a/GameData/WildBlueIndustries/MoreServos/MoreServos.version
+++ b/GameData/WildBlueIndustries/MoreServos/MoreServos.version
@@ -1,6 +1,6 @@
 {
     "NAME":"Kerbal Actuators: More Servos",
-    "URL":"https://raw.githubusercontent.com/Angel-125/MoreServos/master/MoreServos/GameData/WildBlueIndustries/MoreServos/MoreServos.version",
+    "URL":"https://raw.githubusercontent.com/Angel-125/MoreServos/master/GameData/WildBlueIndustries/MoreServos/MoreServos.version",
     "DOWNLOAD":"https://github.com/Angel-125/MoreServos/releases",
     "GITHUB":
     {


### PR DESCRIPTION
Hi @Angel-125!

The version file URL property is a 404:

https://raw.githubusercontent.com/Angel-125/MoreServos/master/MoreServos/GameData/WildBlueIndustries/MoreServos/MoreServos.version

There's an extra instance of the mod name after the branch name. Now it's fixed:

https://raw.githubusercontent.com/Angel-125/MoreServos/master/GameData/WildBlueIndustries/MoreServos/MoreServos.version

Noticed while working on KSP-CKAN/NetKAN#8906.